### PR TITLE
update workflow to fail if linter errors

### DIFF
--- a/.github/workflows/rubocop.yml
+++ b/.github/workflows/rubocop.yml
@@ -3,7 +3,8 @@ name: RuboCop
 on:
   push:
     branches:
-      - master
+      - '*'
+      - '!master'
 
 jobs:
   rubocop:
@@ -18,8 +19,21 @@ jobs:
       with:
         ruby-version: 3.1.1
 
+    - name: Install RuboCop
+      run: bundle add rubocop
+
     - name: Install dependencies
       run: bundle install
 
     - name: Run RuboCop
       run: bundle exec rubocop
+
+    - name: Fail if RuboCop errors
+      run: |
+        set -e
+        bundle exec rubocop
+        result=$?
+        if [ $result -ne 0 ]; then
+          echo "::error::RuboCop errors found. Please fix them before merging."
+          exit 1
+        fi

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -27,3 +27,4 @@ AllCops:
     - 'bin/bundle'
     - 'db/*'
     - 'config/initializers/*'
+    - 'Gemfile'


### PR DESCRIPTION
Lesson Learned: I the workflow can be configured to run on push, therefore I can test before merging.

Here I edit workflow to fail if linter has errors. This way I know to investigate and address them in the event I do not check rubocop after large changes or loading default configs.