### PR TITLE
Add github workflow: rails tests

### DIFF
--- a/.github/workflows/rails_tests.yml
+++ b/.github/workflows/rails_tests.yml
@@ -1,0 +1,51 @@
+name: Rails Tests
+
+on:
+  push:
+    branches:
+      - '*'
+      - '!master'
+  pull_request:
+    branches:
+      - '*'
+      - '!master'
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v3
+
+    - name: Set up Ruby
+      uses: ruby/setup-ruby@v1
+      with:
+        ruby-version: 3.1.1
+
+    - name: Install NodeJS
+      uses: actions/setup-node@v3
+      with:
+        node-version: '16.20.0'
+
+    - name: Install dependencies
+      run: bundle install
+
+    - name: Build assets
+      run: bundle exec rake assets:precompile
+
+    - name: Set up database
+      run: bundle exec rails db:setup
+
+    - name: Run Rails tests
+      run: bundle exec rails test
+
+    - name: Fail if test errors
+      run: |
+        set -e
+        bundle exec rails test
+        result=$?
+        if [ $result -ne 0 ]; then
+          echo "::error::Rails test failures. Please fix them before merging."
+          exit 1
+        fi

--- a/test/models/warranty_test.rb
+++ b/test/models/warranty_test.rb
@@ -33,12 +33,12 @@ class WarrantyTest < ActiveSupport::TestCase
     assert_raises(ActiveRecord::RecordInvalid) do
       short_name.save!
     end
-    assert short_name.errors.messages[:warranty_name], ['is too short (minimum is 2 characters)']
+    assert_equal short_name.errors.messages[:warranty_name], ['is too short (minimum is 2 characters)']
 
     assert_raises(ActiveRecord::RecordInvalid) do
       long_name.save!
     end
-    assert long_name.errors.messages[:warranty_name], ['is too long (maximum is 50 characters)']
+    assert_equal long_name.errors.messages[:warranty_name], ['is too long (maximum is 50 characters)']
   end
 
   test 'Warranty company must be valid' do


### PR DESCRIPTION
Add a Github Workflow to run rails tests. This way, before merging, it can be assured that quality is consistent.

This is just a starting point. This may be refined in the future to execute more successfully