### PR TITLE
Update show controller to present information more clearly

### DIFF
--- a/app/views/warranty/show.html.erb
+++ b/app/views/warranty/show.html.erb
@@ -1,19 +1,15 @@
-<div>
-  <p>
-    <%= @warranty.warranty_name %>
-  </p>
-
-  <p>
-    <%= @warranty.warranty_company %>
-  </p>
-
-  <p>
-    <%= @warranty.extra_info %>
-  </p>
+<div id='Warranty Show'>
+  <p>Warranty Name: <%= @warranty.warranty_name %></p>
+  <p>Warranty Company: <%= @warranty.warranty_company %></p>
+  <% unless @warranty.extra_info.nil? || @warranty.extra_info.empty? %>
+    <p>Extra Info: <%= @warranty.extra_info %></p>
+  <% end %>
+  <p>Start Date: <%= @warranty.warranty_start_date %></p>
+  <p>End Date: <%= @warranty.warranty_end_date || 'Lifetime' %></p>
 </div>
-
 <div>
-  <%= link_to 'Home', warranty_index_path %>
-  <%= link_to 'Edit', edit_warranty_path(@warranty) %>
-  <%= link_to 'Delete', warranty_path(@warranty), data: { method: :delete, confirm: "Are you sure?" } %>
+  <!-- The class 'btn' here is for when bootstrap is added-->
+  <%= link_to 'Home', warranty_index_path, class: 'btn btn-primary' %>
+  <%= link_to 'Edit', edit_warranty_path(@warranty), class: 'btn' %>
+  <%= link_to 'Delete', warranty_path(@warranty), data: { method: :delete, confirm: "Are you sure?" }, class: 'btn' %>
 </div>

--- a/test/controllers/warranty_controller_test.rb
+++ b/test/controllers/warranty_controller_test.rb
@@ -55,10 +55,31 @@ class WarrantyControllerTest < ActionDispatch::IntegrationTest
   end
 
   test 'Show warranty' do
-    get warranty_path(@warranty)
+    show_warranty = FactoryBot.create(:warranty, user: @user, extra_info: 'something', warranty_end_date: 1.day.ago)
+
+    get warranty_path(show_warranty)
     assert_response :success
-    assert_select 'p', @warranty.warranty_name
-    assert_select 'p', @warranty.warranty_company
+    assert_match show_warranty.warranty_name, response.body
+    assert_match show_warranty.warranty_company, response.body
+    assert_match show_warranty.extra_info, response.body
+    assert_match show_warranty.warranty_start_date.to_s, response.body
+    assert_match show_warranty.warranty_end_date.to_s, response.body
+  end
+
+  test 'Show warranty does not display extra info if field is empty' do
+    no_extra_info = FactoryBot.create(:warranty, user: @user, warranty_end_date: 1.day.ago)
+
+    get warranty_path(no_extra_info)
+    assert_response :success
+    assert_no_match 'Extra Info', response.body
+  end
+
+  test 'Show warranty displays "Lifetime" if warranty_end_date is empty' do
+    no_end_date = FactoryBot.create(:warranty, user: @user, extra_info: 'something')
+
+    get warranty_path(no_end_date)
+    assert_response :success
+    assert_match 'Lifetime', response.body
   end
 
   test 'Display Index if navigating to other user\'s warranty' do
@@ -79,8 +100,8 @@ class WarrantyControllerTest < ActionDispatch::IntegrationTest
     assert_response :redirect
     follow_redirect!
     assert_response :success
-    assert_select 'p', 'Gaming Chair'
-    assert_select 'p', 'Razr'
+    assert_match 'Gaming Chair', response.body
+    assert_match 'Razr', response.body
   end
 
   test 'Error during create warranty' do
@@ -103,7 +124,7 @@ class WarrantyControllerTest < ActionDispatch::IntegrationTest
     assert_response :redirect
     follow_redirect!
     assert_response :success
-    assert_select 'p', 'robin-hood'
+    assert_match 'robin-hood', response.body
   end
 
   test 'Error during update warranty' do


### PR DESCRIPTION
This show endpoint wasn't clearly articulating warranty information entered.

If `extra_info` is nil or empty, do not display row.
If `warranty_end_date` is nil, display "Lifetime".

Updated show view:
<img width="231" alt="Screenshot 2023-04-23 at 1 13 12 PM" src="https://user-images.githubusercontent.com/32687345/233863417-52da18ba-34f4-495b-b352-0b1caf946dd1.png">
