### PR TITLE
start date must be less than end date

### DIFF
--- a/app/assets/javascripts/validations_input_changes.js
+++ b/app/assets/javascripts/validations_input_changes.js
@@ -78,7 +78,7 @@ $(document).ready(function() {
     if (isNaN(startDate)) {
         return 'please select a date'
     }
-    if (startDate > endDate){
+    if (startDate >= endDate){
         return 'must be before end date OR end date should be cleared'
     } else {
         return null


### PR DESCRIPTION
Front-end validation is not occurring when `start_date` is equal to `end_date`
<img width="338" alt="Screenshot 2023-04-23 at 8 25 46 PM" src="https://user-images.githubusercontent.com/32687345/233894486-bd9658e7-fed5-4b0e-9859-0da6d8aee0d4.png">

And when user tries to create warranty, back-end validation kicks in
<img width="339" alt="Screenshot 2023-04-23 at 8 25 59 PM" src="https://user-images.githubusercontent.com/32687345/233894623-39ac7a88-570c-424c-86bf-01bc0f4e55ae.png">

How it should appear [fix]:
<img width="394" alt="Screenshot 2023-04-23 at 8 37 19 PM" src="https://user-images.githubusercontent.com/32687345/233894801-f0a5609b-122e-427a-8623-ae5dae5d664d.png">
