### PR TITLE
Add handling on Index page for when there are no current warranties

### DIFF
--- a/app/views/warranty/_table.html.erb
+++ b/app/views/warranty/_table.html.erb
@@ -1,6 +1,6 @@
-<% unless any_warranties.empty? %>
+<% if !any_warranties.empty? %>
   <table class='container table'>
-    <h3 style='text-align: center;'><%= title %></h3>
+    <h3><%= title %></h3>
     <head>
       <tr class='row'>
         <th class='col'>Name</th>
@@ -23,4 +23,7 @@
       <% end %>
     </body>
   </table>
+<% elsif title == 'Current Warranties' %>
+  <h3><%= title %></h3>
+  <h5 class='my-deep-brown'>None! Try adding a new warranty...</h5>
 <% end %>

--- a/test/controllers/warranty_controller_test.rb
+++ b/test/controllers/warranty_controller_test.rb
@@ -37,8 +37,27 @@ class WarrantyControllerTest < ActionDispatch::IntegrationTest
     sign_in new_user
 
     get warranty_index_path
-    assert_select 'Current Warranties', false
+
+    assert_match 'Current Warranties', response.body
+    assert_match 'None! Try adding a new warranty...', response.body
     assert_select 'Expired Warranties', false
+  end
+
+  test 'Index current warranties displays default if current warranties expire' do
+    new_user = FactoryBot.create(:user)
+    sign_in new_user
+
+    w = FactoryBot.create(:warranty, user: new_user)
+    get warranty_index_path
+
+    assert_select 'h3', 'Current Warranties'
+    assert_match w.warranty_name, response.body
+
+    w.update!(expired: true)
+    get warranty_index_path
+
+    assert_match 'Current Warranties', response.body
+    assert_match 'None! Try adding a new warranty...', response.body
   end
 
   test 'Index will not display expired warranties table if there are no expired warranties' do


### PR DESCRIPTION
When logging in as a new user, there is nothing displayed except a button to add warranties.

Instead, add default message to appear if there are no current warranties.
<img width="1084" alt="Screenshot 2023-04-27 at 7 05 43 PM" src="https://user-images.githubusercontent.com/32687345/235036958-dd6e8cae-eac6-4992-b107-6681f9322b7a.png">
